### PR TITLE
Suppress HTML preamble from user directories

### DIFF
--- a/templates/userdir.conf.j2
+++ b/templates/userdir.conf.j2
@@ -29,8 +29,8 @@
 # for a site where these directories are restricted to read-only.
 #
 <Directory "/home/*/public_html">
+    IndexOptions NameWidth=* +SuppressHTMLPreamble
     AllowOverride FileInfo AuthConfig Limit Indexes
     Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
     Require method GET POST OPTIONS
 </Directory>
-


### PR DESCRIPTION
- Previously, documents showing user directories had duplicated HTML
  preambles. The one we provide in /centos-design/header.html template
  and the one Apache provides internally. As consequence the layout is
  not the one expected. This update suppresses Apache internal HTML
  preamble so to use the one we provide and no duplicate HTML preamble
  does exist.