### PR TITLE
Add centos-sponsors.css

### DIFF
--- a/files/centos-design/css/centos-sponsors.css
+++ b/files/centos-design/css/centos-sponsors.css
@@ -1,0 +1,8 @@
+/* Footer showing sponsors
+-------------------------------------------------- */
+body {
+  margin-bottom: 250px; /* Margin bottom by footer height */
+}
+.footer {
+  height: 250px; /* Set the fixed height of the footer here */
+}


### PR DESCRIPTION
- Previously, footer with sponsors and footer without sponsors were
  treated the same way. However, they have different heights. This
  update adds the centos-sponsors.css file to reset properties related
  to sponsors, footer presentation included.