### PR TITLE
Update variables, templates and tasks for people

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -111,6 +111,14 @@ httpd_mirrorlist_internal_url: mirror.centos.org
 httpd_people_hostname: people.centos.org
 
 # ===============================================================================
+# httpd_people_dirname - Set people entry point.
+#
+# This is the absolute path to the directory where people index.html will be
+# stored in. This is where the list of users is presented.
+# ===============================================================================
+httpd_people_dirname: "/var/www/people"
+
+# ===============================================================================
 # httpd_common_alias - Set http alias to common http resources
 #
 # This is the location that will be used in the ErrorDocument directive to
@@ -201,7 +209,7 @@ httpd_navbar:
 # ===============================================================================
 httpd_social:
   - icon: "fab fa-twitter"
-    link: "https://twitter.com/centosproject"
+    link: "https://twitter.com/centos"
   - icon: "fab fa-youtube"
     link: "https://youtube.com/TheCentOSProject"
   - icon: "fab fa-linkedin"

--- a/tasks/vhost-people.yml
+++ b/tasks/vhost-people.yml
@@ -16,7 +16,7 @@
     group: "{{ item.login_name }}"
     mode: 0775
     setype: httpd_user_content_t
-  with_items: "{{ people_users }}" 
+  with_items: "{{ people_users }}"
   loop_control:
     label : "{{ item.login_name }}"
 
@@ -27,26 +27,34 @@
     owner: "{{ item.login_name }}"
     group: "{{ item.login_name }}"
     mode: 0711
-  with_items: "{{ people_users }}" 
+  with_items: "{{ people_users }}"
   loop_control:
     label : "{{ item.login_name }}"
 
 - name: Creating DocumentRoot for people vhost
   file:
-    path: /var/www/people
+    path: "{{ httpd_people_dirname }}"
     state: directory
     mode: 0755
 
-- name: Creating users list for people vhost
+- name: Creating index.html for people vhosts
   template:
     src: people-users.j2
-    dest: /var/www/people/users.html
+    dest: "{{ httpd_people_dirname }}/index.html"
     mode: 0644
-  register: user_list_html
 
-- name: Creating index.html for people vhosts
-  shell: cat /var/www/centos-design/header-{{ httpd_html_autoindex_title | lower | replace(" ","-") }}.html /var/www/people/users.html /var/www/centos-design/footer.html > /var/www/people/index.html
-  when: user_list_html is changed
+- name: Creating HEADER files for people
+  template:
+    src: common/header-user.html.j2
+    dest: "{{ httpd_people_dirname }}/HEADER-{{ item.login_name }}.html"
+    mode: 0644
+  with_items: "{{ people_users }}"
+
+- name: Creating FOOTER file for people
+  template:
+    src: common/footer.html.j2
+    dest: "{{ httpd_people_dirname }}/FOOTER.html"
+    mode: 0644
 
 - name: Configuring httpd vhost for people
   template:

--- a/templates/common/header-user.html.j2
+++ b/templates/common/header-user.html.j2
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+    <title>{{ item.full_name }} | People of CentOS</title>
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ httpd_assets_url }}/assets/img/favicon.png">
+    <link rel="stylesheet" href="{{ httpd_assets_url }}/assets/css/centos-httpd.bootstrap.min.css">
+  </head>
+  <body>
+    {% include "common/header-navbar.html.j2" %}
+    <header class="header header__page">
+      <h1 class="header__page__title">{{ item.full_name }}</h1>
+      <p class="header__page__description">{{ item.login_name }}</p>
+    </header>
+    <div class="hr">
+    <div class="hr__centos-color-0"></div>
+    <div class="hr__centos-color-1"></div>
+    <div class="hr__centos-color-2"></div>
+    <div class="hr__centos-color-3"></div>
+    </div>
+    <main class="page">
+      <article class="page__content">
+        <div class="page__content__nav">
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ httpd_assets_url }}/">Home</a></li>
+            <li class="breadcrumb-item"><a href="https://{{ httpd_people_hostname }}/">People of CentOS</a></li>
+            <li class="breadcrumb-item">{{ item.full_name }}</li>
+          </ol>
+        </div>
+        <div class="page__content__autoindex">

--- a/templates/common/header.html.j2
+++ b/templates/common/header.html.j2
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+    <title>{{ title }}</title>
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ httpd_assets_url }}/assets/img/favicon.png">
+    <link rel="stylesheet" href="{{ httpd_assets_url }}/assets/css/centos-httpd.bootstrap.min.css">
+  </head>
+  <body>
+    {% include "common/header-navbar.html.j2" %}
+    <header class="header header__page">
+      <h1 class="header__page__title">{{ title }}</h1>
+      <p class="header__page__description">{{ title_lead }}</p>
+    </header>
+    <div class="hr">
+    <div class="hr__centos-color-0"></div>
+    <div class="hr__centos-color-1"></div>
+    <div class="hr__centos-color-2"></div>
+    <div class="hr__centos-color-3"></div>
+    </div>
+    <main class="page">
+      <article class="page__content">
+        <div class="page__content__nav">
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ httpd_assets_url }}/">Home</a></li>
+            <li class="breadcrumb-item">{{ title }}</li>
+          </ol>
+        </div>
+        <div class="page__content__autoindex">
+{% for i in alerts %}
+          <div class="{{ i.class }}" role="alert">
+            <strong>{{ i.title }}</strong> {{ i.message }}
+          </div>
+{% endfor %}
+{% for i in paragraphs %}
+          <p>{{ i }}</p>
+{% endfor %}

--- a/templates/docs-sigs/index.html.j2
+++ b/templates/docs-sigs/index.html.j2
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>
  <head>
-  <title>Index of /9-stream/kmods/x86_64/packages-rebuild/Packages/k</title>
+  <title>CentOS SIGs Documentation site</title>
   <link rel="stylesheet" href="/centos-design/css/centos-listindex.css" type="text/css">
  </head>
  <body>

--- a/templates/people-users.j2
+++ b/templates/people-users.j2
@@ -1,18 +1,27 @@
-  <h1>People of CentOS</h1>
+{% with %}
+{# --- Header template configuration --------------------------- #}
+{% set title = "People of CentOS" %}
+{% set title_lead = "This is an area where the CentOS Developers and allowed contributors can make test files and other things available that are not yet part of CentOS. Some items here will make it into CentOS, CentOS Extras and/or CentOS Plus ... while other things may not." %}
+{% set alerts = [{
+  'title': '<i class="fas fa-exclamation-triangle"></i> Caution:',
+  'class': 'alert alert-danger',
+  'message': 'Use anything here at your own risk!'
+  }]
+%}
+{% set paragraphs = [
+  'The following users currently have areas on people.centos.org: (sorted by First name)'
+  ]
+%}
+{# --- Header template ----------------------------------------- #}
+{% include "common/header.html.j2" %}
+{% endwith %}
 
-  <p>This is an area where the CentOS Developers and allowed contributors can
-  make test files and other things available that are not yet part of CentOS.
-  <br> Some items here will make it into CentOS, CentOS Extras and/or CentOS
-  Plus ... while other things may not.</p>
+{# --- Body ---------------------------------------------------- #}
+<ul class="list-group list-group-flush">
+{% for user in people_users|sort(attribute='full_name') %}
+<li class="list-group-item"><a href="/{{ user.login_name }}/">{{ user.full_name }} ({{ user.login_name }})</a></li>
+{% endfor %}
+</ul>
 
-  <div class="alert alert-danger" role="alert">
-    <strong>Caution:</strong> Use anything here at your own risk!!!!
-  </div>
-
-  <p>The following users currently have areas on people.centos.org: (sorted by First name)</p>
-
-  <ul>
-  {% for user in people_users|sort(attribute='full_name') %}
-  <li> <a href="/{{ user.login_name }}/">{{ user.full_name }} ({{ user.login_name }})</a></li>
-  {% endfor %}
-  </ul>
+{# --- Footer -------------------------------------------------- #}
+{% include "common/footer.html.j2" %}

--- a/templates/ssl-people.conf.j2
+++ b/templates/ssl-people.conf.j2
@@ -1,5 +1,5 @@
 <VirtualHost *:443>
-DocumentRoot "/var/www/people"
+DocumentRoot "{{ httpd_people_dirname }}"
 
   Header always set Strict-Transport-Security "max-age=31536000"
   Header always set X-Xss-Protection "1; mode=block"
@@ -13,12 +13,6 @@ DocumentRoot "/var/www/people"
   RewriteCond /home/%1 -d
   RewriteRule ^/([^/]+)(.*) /home/$1/public_html/$2
 
-  HeaderName /centos-design/header.html
-  ReadmeName /centos-design/footer.html
-  # Global for each user directory
-  IndexOptions +SuppressHTMLPreamble NameWidth=*
-  IndexStyleSheet "/centos-design/css/centos-listindex.css"
-
   <Directory "/var/www/people">
     Options Indexes FollowSymLinks
     <IfVersion < 2.4>
@@ -26,8 +20,6 @@ DocumentRoot "/var/www/people"
     Allow from all
     </IfVersion>
     <IfVersion >= 2.4>
-    IndexOptions +SuppressHTMLPreamble NameWidth=*
-    IndexStyleSheet "/centos-design/css/centos-listindex.css"
     Require all granted
     </IfVersion>
   </Directory>

--- a/templates/userdir.conf.j2
+++ b/templates/userdir.conf.j2
@@ -29,8 +29,24 @@
 # for a site where these directories are restricted to read-only.
 #
 <Directory "/home/*/public_html">
-    IndexOptions NameWidth=* +SuppressHTMLPreamble
+    IndexOptions FancyIndexing -HTMLTable VersionSort SuppressHTMLPreamble XHTML
     AllowOverride FileInfo AuthConfig Limit Indexes
     Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
     Require method GET POST OPTIONS
+    Require all granted
 </Directory>
+
+#
+# Autoindex headers. The header information is specific for each single user.
+#
+{% for user in people_users %}
+<Directory "/home/{{ user.login_name }}/public_html">
+  HeaderName /HEADER-{{ user.login_name }}.html
+</Directory>
+{% endfor %}
+
+#
+# Autoindex footer. The footer information is common to all users.
+#
+ReadmeName /FOOTER.html
+


### PR DESCRIPTION
- Previously, the user-specific pages didn't provide any reference about
  the user name other than the one in the URL. This update changes the
  visual presentation of user-specific pages to provide the user full
  name and username in the page's header section.

- Previously, the user-specific pages were all using the "CentOS Web
  Style" title. This update fixes the user-specific pages' title to have
  the form "<User Full Name> | People of CentOS" instead.

- Previously, the people-related pages didn't have a navigation
  breadcrumb. As consequence it was difficult to get oriented inside the
  site. This update changes the visual presentation of people pages to
  include a breadcrumb with current position in CentOS site to improve
  the user browsing orientation.