### PR TITLE
Update header design for autoindex sites

### DIFF
--- a/templates/header.html.j2
+++ b/templates/header.html.j2
@@ -1,89 +1,35 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Required meta tags -->
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-
-    <!-- CentOS customization -->
-    <link rel="stylesheet" href="/centos-design/css/centos.css">
-    <link rel="stylesheet" href="/centos-design/css/centos-listindex.css">
-
-    <!-- Favicon -->
-    <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />
-
-    <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css?family=Exo+2&display=swap" rel="stylesheet">
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <title>{{ httpd_html_autoindex_title }}</title>
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ httpd_assets_url }}/assets/img/favicon.png">
+    <link rel="stylesheet" href="{{ httpd_assets_url }}/assets/css/centos-httpd.bootstrap.min.css">
   </head>
-
-  <body class="d-flex flex-column h-100">
-
-    <header>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-    <a class="navbar-brand" href="https://www.centos.org/">
-      <img src="/centos-design/images/centos-logo-white.png" height="32" alt="CentOS">
-    </a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav mr-auto">
-        <li class="nav-item">
-          <a class="nav-link" href="https://www.centos.org/download">Download</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            About
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item" href="https://www.centos.org/about/">About CentOS</a>
-            <a class="dropdown-item" href="https://wiki.centos.org/FAQ">Frequently Asked Questions (FAQs)</a>
-            <a class="dropdown-item" href="https://wiki.centos.org/SpecialInterestGroup">Special Interest Groups (SIGs)</a>
-            <a class="dropdown-item" href="https://www.centos.org/variants/">CentOS Variants</a>
-            <a class="dropdown-item" href="https://www.centos.org/about/governance/">Governance</a>
-          </div>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Community
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item" href="https://wiki.centos.org/Contribute">Contribute</a>
-            <a class="dropdown-item" href="https://www.centos.org/forums/">Forums</a>
-            <a class="dropdown-item" href="https://wiki.centos.org/GettingHelp/ListInfo">Mailing Lists</a>
-            <a class="dropdown-item" href="https://wiki.centos.org/irc">IRC</a>
-            <a class="dropdown-item" href="https://www.centos.org/community/calendar/">Calendar &amp; IRC Meeting List</a>
-            <a class="dropdown-item" href="http://planet.centos.org/">Planet</a>
-            <a class="dropdown-item" href="https://bugs.centos.org/">Submit a Bug</a>
-            <a class="dropdown-item" href="https://www.centos.org/community/stories/">Stories</a>
-          </div>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Documentation
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item" href="https://wiki.centos.org/">Wiki</a>
-            <a class="dropdown-item" href="https://docs.centos.org/">Manuals</a>
-            <a class="dropdown-item" href="https://www.centos.org/keys">GPG Key Info</a>
-          </div>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="https://wiki.centos.org/Documentation?action=show&redirect=GettingHelp">Help</a>
-        </li>
-      </ul>
-    </div>
-    </nav>
+  <body>
+    {% include "common/header-navbar.html.j2" %}
+    <header class="header header__page">
+      <h1 class="header__page__title">{{ httpd_html_autoindex_title }}</h1>
+      {% if httpd_html_autoindex_description %}
+      <p class="header__page__description">{{ httpd_html_autoindex_description }}</p>
+      {% endif %}
     </header>
+    <div class="hr">
+    <div class="hr__centos-color-0"></div>
+    <div class="hr__centos-color-1"></div>
+    <div class="hr__centos-color-2"></div>
+    <div class="hr__centos-color-3"></div>
+    </div>
+    <main class="page">
+      <article class="page__content">
+        <div class="page__content__nav">
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ httpd_assets_url }}/">Home</a></li>
+            <li class="breadcrumb-item">{{ httpd_html_autoindex_title }}</li>
+          </ol>
+        </div>
+        <div class="page__content__autoindex">
 
-    <main>
-    <div class="container mt-4 mb-4">
-
-    {{ httpd_html_autoindex_content }}
+{{ httpd_html_autoindex_content }}
 


### PR DESCRIPTION
- Previously, autoindex sites like mirror.centos.org were using a
  header design different to sites like people.centos.org or
  www.centos.org. This update changes autoindex header design to
  visually integrate it into www.centos.org design.

- Previously, there was no breadcrumbs on autoindex sites, so it was
  difficult for users to be aware of their location during site
  navigation. This update adds breadcrumbs to autoindex sites to improve
  user location awareness during navigation.

- Previously, the navigation navbar was explicitly defined in the page,
  making its maintenance difficult when links change in a different
  site.  This update removes the explicit navbar definition in autoindex
  sites and includes the code other sites use. So, we have one single
  point of change to propagate navbar updates faster and consistently
  among sites.

- Add `httpd_html_autoindex_description` variable to control autoindex
  page description paragraph in the page header. This variable is
  optional.