### PR TITLE
Normalize IndexOptions so tables look alike

### DIFF
--- a/templates/99_reposnap.conf.j2
+++ b/templates/99_reposnap.conf.j2
@@ -15,7 +15,7 @@ Alias /reposnap/ {{ reposnap_local_dir }}/reposnap
     Allow from all
   </IfVersion>
   <IfVersion >= 2.4>
-    IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+    IndexOptions FancyIndexing NameWidth=* -HTMLTable VersionSort SuppressDescription SuppressHTMLPreamble XHTML Charset=UTF-8
     Require all granted
   </IfVersion>
  </Directory>

--- a/templates/99_vhost-shared-dir.conf.j2
+++ b/templates/99_vhost-shared-dir.conf.j2
@@ -21,7 +21,7 @@
 {% endif %}
   </IfVersion>
   <IfVersion >= 2.4>
-    IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+  IndexOptions FancyIndexing NameWidth=* -HTMLTable VersionSort SuppressDescription SuppressHTMLPreamble XHTML Charset=UTF-8
 {% if item.acl is defined %}
 {% for allowed in item.acl %}
     Require ip {{ allowed }}

--- a/templates/armv7/ssl-armv7-dev.conf.j2
+++ b/templates/armv7/ssl-armv7-dev.conf.j2
@@ -13,7 +13,7 @@ Alias /rpmbuild /rpmbuild
  <Directory "/rpmbuild">
   AllowOverride Indexes
   Options Indexes FollowSymLinks MultiViews
-  IndexOptions NameWidth=*
+  IndexOptions FancyIndexing NameWidth=* -HTMLTable VersionSort SuppressDescription SuppressHTMLPreamble XHTML Charset=UTF-8
   <IfVersion < 2.4>
     Order allow,deny
     Allow from all
@@ -30,7 +30,7 @@ Alias /repodir /repodir
  <Directory "/repodir">
   AllowOverride Indexes
   Options Indexes FollowSymLinks MultiViews
-  IndexOptions NameWidth=*
+  IndexOptions FancyIndexing NameWidth=* -HTMLTable VersionSort SuppressDescription SuppressHTMLPreamble XHTML Charset=UTF-8
   <IfVersion < 2.4>
     Order allow,deny
     Allow from all
@@ -45,7 +45,7 @@ Alias /repos /repos
  <Directory "/repos">
   AllowOverride Indexes
   Options Indexes FollowSymLinks MultiViews
-  IndexOptions NameWidth=*
+  IndexOptions FancyIndexing NameWidth=* -HTMLTable VersionSort SuppressDescription SuppressHTMLPreamble XHTML Charset=UTF-8
   <IfVersion < 2.4>
     Order allow,deny
     Allow from all

--- a/templates/userdir.conf.j2
+++ b/templates/userdir.conf.j2
@@ -29,7 +29,7 @@
 # for a site where these directories are restricted to read-only.
 #
 <Directory "/home/*/public_html">
-    IndexOptions FancyIndexing -HTMLTable VersionSort SuppressHTMLPreamble XHTML
+    IndexOptions FancyIndexing NameWidth=* -HTMLTable VersionSort SuppressDescription SuppressHTMLPreamble XHTML Charset=UTF-8
     AllowOverride FileInfo AuthConfig Limit Indexes
     Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
     Require method GET POST OPTIONS


### PR DESCRIPTION
- Previously, the autoindex table in people.centos.org/username/ and
  autoindex tables in sites like mirror.centos.org look different. This
  update changes IndexOptions so they look alike.

- Remove the Description field to provide more space for the Name field,
  in case it needs it.