### PR TITLE
fix: 🐛 use httpd_*_hostname instead of httpd_www_domain

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -169,7 +169,7 @@ httpd_common_directory: "/var/www/common"
 # playbooks you run can take advantage of it reducing the number of places you
 # need to change.
 # ===============================================================================
-httpd_common_assets: "https://www.centos.org"
+httpd_common_assets: "https://{{ httpd_www_hostname }}"
 
 # ===============================================================================
 # httpd_common_navbar - Set website navigation bar.

--- a/templates/common/page-header-user.html.j2
+++ b/templates/common/page-header-user.html.j2
@@ -9,7 +9,7 @@
     <div class="col">
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
-          <li class="breadcrumb-item"><a class="link-offset-3 link-offset-3-hover link-underline link-underline-opacity-25 link-underline-opacity-75-hover" href="https://www.{{ httpd_www_domain }}">Home</a></li>
+          <li class="breadcrumb-item"><a class="link-offset-3 link-offset-3-hover link-underline link-underline-opacity-25 link-underline-opacity-75-hover" href="https://{{ httpd_www_hostname }}">Home</a></li>
           <li class="breadcrumb-item"><a class="link-offset-3 link-offset-3-hover link-underline link-underline-opacity-25 link-underline-opacity-75-hover" href="https://{{ httpd_people_hostname }}">People of CentOS</a></li>
           <li class="breadcrumb-item active">{{ item.login_name }}</li>
         </ol>

--- a/templates/common/page-header.html.j2
+++ b/templates/common/page-header.html.j2
@@ -9,7 +9,7 @@
     <div class="col">
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
-          <li class="breadcrumb-item"><a class="link-offset-3 link-offset-3-hover link-underline link-underline-opacity-25 link-underline-opacity-75-hover" href="https://www.{{ httpd_www_domain }}">Home</a></li>
+          <li class="breadcrumb-item"><a class="link-offset-3 link-offset-3-hover link-underline link-underline-opacity-25 link-underline-opacity-75-hover" href="https://{{ httpd_www_hostname }}">Home</a></li>
           <li class="breadcrumb-item active">{{ page.title }}</li>
         </ol>
       </nav>

--- a/templates/common/page-navbar.html.j2
+++ b/templates/common/page-navbar.html.j2
@@ -1,6 +1,6 @@
 <nav class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark bg-image shadow" aria-label="navbar">
   <div class="container">
-    <a class="navbar-brand" href="https://www.{{ httpd_www_domain }}/"><img src="{{ httpd_common_assets }}/assets/img/{{ page.with_logo | default('centos-whitelogo.svg') }}" height="32" alt="{{ httpd_common_title }}" />{% if page.with_manifestation != "" %}<span class="manifestation border-start border-light ps-3 ms-3 py-2 fs-6">{{ page.with_manifestation }}</span>{% endif %}</a>
+    <a class="navbar-brand" href="https://{{ httpd_www_hostname }}/"><img src="{{ httpd_common_assets }}/assets/img/{{ page.with_logo | default('centos-whitelogo.svg') }}" height="32" alt="{{ httpd_common_title }}" />{% if page.with_manifestation != "" %}<span class="manifestation border-start border-light ps-3 ms-3 py-2 fs-6">{{ page.with_manifestation }}</span>{% endif %}</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>


### PR DESCRIPTION
The `httpd_www_domain` variable has no default value in `httpd` role while `httpd_www_hostname` and `httpd_people_hostname` variables do. This commit updates templates and role default values to reuse hostname variables that already exist to create links.